### PR TITLE
Updated Neo React library

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 	"dependencies": {
 		"@astrojs/netlify": "5.5.4",
 		"@astrojs/prefetch": "0.4.1",
-		"@avaya/neo-react": "1.4.6",
+		"@avaya/neo-react": "1.4.7",
 		"@nanostores/react": "0.8.0",
 		"clsx": "2.1.1",
 		"dayjs": "1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,14 +137,14 @@
   resolved "https://registry.yarnpkg.com/@atomic-layout/core/-/core-0.14.1.tgz#3d69be5f79775f11b8008f18bc603b04a2141ccd"
   integrity sha512-o5nhk/1djuKzB20C2LSOuetTDytsbGg4c0UfxXkq1pqoaN3hKJcHPYF9nV+p6+P5CWqNBaaJddZ32OsFSppULQ==
 
-"@avaya/neo-react@1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@avaya/neo-react/-/neo-react-1.4.6.tgz#42dd2122b5ba43eca4e7788dfdb9db9818722226"
-  integrity sha512-58DN9y9KtbaXplcjKkvwCy82AHGZLwD3MYlwftZq3CC8YoKvI1rnj6jOdlo6UfxF2Mzg/VGwnFkpxA3c8MuBQg==
+"@avaya/neo-react@1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@avaya/neo-react/-/neo-react-1.4.7.tgz#a35b7590dc2bf4c7672d2104ff5aef87e3996639"
+  integrity sha512-aab9wFEh+4hYyDdv5DWu8wtZRdI3pnFPv3WO+AxuY7mrBFo3ckUuoWBAChZeBHms7tpSzAdmA4n6zI2N9x1JTQ==
   dependencies:
     atomic-layout "0.16.2"
     loglevel "1.9.2"
-    react-click-away-listener "2.2.3"
+    react-click-away-listener "2.2.4"
     react-fast-compare "3.2.2"
     react-focus-lock "2.13.2"
     styled-components "6.1.13"
@@ -6578,10 +6578,10 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-click-away-listener@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-click-away-listener/-/react-click-away-listener-2.2.3.tgz#a5c3e37d94cc86dac3546dbb753db14bacb63186"
-  integrity sha512-p63JRQtK9d085+QHUJ2Pje22P/N4tEaXsS2x7tbbptriQqZ9o8xEk7G1JrxwND5YmEVc/VO4fC3+cSBsqqgLUQ==
+react-click-away-listener@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-click-away-listener/-/react-click-away-listener-2.2.4.tgz#0bb69c5d9b456850bb7b8bc2588f8b873970a84a"
+  integrity sha512-cwdiIPt5dlNATewJIj/oro9aHg61vjnpkMzL4TfA3+lY4zNWV6d9PxWDSXFCYlADcb0bnVlGWVFkyY+WzFXznA==
 
 react-clientside-effect@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
Updated React library from 1.4.6 to 1.4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `@avaya/neo-react` dependency from 1.4.6 to 1.4.7 in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->